### PR TITLE
feat: add client-side search for paths

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
+import "./.next/dev/types/routes.d.ts";
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/app/paths/page.tsx
+++ b/src/app/paths/page.tsx
@@ -1,5 +1,6 @@
+import PathsClient from "@/components/PathsClient";
 import { paths } from "@/data";
-import PathCard from "@/components/PathCard";
+
 
 export const metadata = {
   title: "All Paths | WebPath",
@@ -16,13 +17,8 @@ export default function PathsPage() {
           journey from beginner to advanced topics.
         </p>
       </div>
-      <section className="section">
-        <div className="paths-grid">
-          {paths.map((path) => (
-            <PathCard key={path.slug} path={path} />
-          ))}
-        </div>
-      </section>
+
+      <PathsClient paths={paths} />
     </>
   );
 }

--- a/src/components/PathsClient.tsx
+++ b/src/components/PathsClient.tsx
@@ -1,0 +1,58 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Path } from "@/data/types";
+import PathCard from "./PathCard";
+import SearchBar from "./SearchBar";
+
+export default function PathsClient({ paths }: { paths: Path[] }) {
+    const [query, setQuery] = useState("");
+
+    const filteredPaths = useMemo(() => {
+        const q = query.trim().toLowerCase();
+        if (!q) return paths;
+
+        return paths.filter((path) => {
+            const matchesTitle = path.title.toLowerCase().includes(q);
+            const matchesDescription = path.description
+                .toLowerCase()
+                .includes(q);
+            const matchesLevel = path.topics.some((topic) =>
+                topic.level.toLowerCase().includes(q)
+            );
+
+            return matchesTitle || matchesDescription || matchesLevel;
+        });
+    }, [query, paths]);
+
+    return (
+        <>
+            <div className="section">
+                <div className="flex justify-center">
+                    <div className="w-full max-w-md">
+                        <SearchBar
+                            placeholder="Search paths by name, description, or level..."
+                            onChange={setQuery}
+                        />
+                    </div>
+                </div>
+            </div>
+
+            <section className="section">
+                <div className="paths-grid">
+                    {filteredPaths.length > 0 ? (
+                        filteredPaths.map((path) => (
+                            <PathCard key={path.slug} path={path} />
+                        ))
+                    ) : (
+                        <div className="col-span-full">
+                            <p className="text-center text-sm md:text-base text-muted-foreground py-12">
+                                No paths found.
+                            </p>
+                        </div>
+                    )}
+                </div>
+            </section>
+        </>
+    );
+}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useState } from "react";
+
+interface SearchBarProps {
+    placeholder?: string;
+    onChange: (value: string) => void;
+}
+
+export default function SearchBar({
+    placeholder = "Search...",
+    onChange,
+}: SearchBarProps) {
+    const [value, setValue] = useState("");
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+        const newValue = e.target.value;
+        setValue(newValue);
+        onChange(newValue);
+    };
+
+    const handleClear = () => {
+        setValue("");
+        onChange("");
+    };
+
+    return (
+        <div className="w-full">
+            <label htmlFor="search" className="sr-only">
+                Search
+            </label>
+
+            <div className="relative w-full">
+                <input
+                    id="search"
+                    type="text"
+                    placeholder={placeholder}
+                    value={value}
+                    onChange={handleChange}
+                    style={{ paddingLeft: "1rem", paddingRight: value ? "2rem" : "1rem" }}
+                    className="w-full h-9 rounded-lg bg-gray-50 border border-gray-200 text-sm leading-normal outline-none transition placeholder:text-gray-400 focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+                />
+
+                {value && (
+                    <button
+                        onClick={handleClear}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 transition-colors cursor-pointer"
+                        aria-label="Clear search"
+                    >
+                        ✕
+                    </button>
+                )}
+            </div>
+        </div>
+    );
+}


### PR DESCRIPTION
Implements client-side search on /paths page filtering by title, description, and level.  
Adds a reusable SearchBar component and keeps the page as a Server Component with client-side filtering.