### PR TITLE
Fix Cloudflare preview deploy: bump Node to 22, pin wrangler 4

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: npm
 
       - run: npm ci
@@ -32,6 +32,7 @@ jobs:
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.87.0"
           command: versions upload --message "PR #${{ github.event.pull_request.number }} - ${{ github.event.pull_request.head.sha }}"
 
       - name: Comment preview URL on PR

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0",
   "private": true,
   "engines": {
-    "node": ">=20.0.0"
+    "node": ">=22.0.0"
   },
   "scripts": {
     "build": "next build --webpack",


### PR DESCRIPTION
## Summary
- Bumps CI Node from 20 → 22 in `.github/workflows/preview.yml` (wrangler 4.x requires Node 22+)
- Pins `wranglerVersion: "4.87.0"` on `cloudflare/wrangler-action@v3` so it doesn't silently fall back to wrangler 3.90.0
- Bumps `engines.node` to `>=22.0.0` so local installs match CI

## Why
The Cloudflare preview job was failing with:

> `Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.`

The action then installed wrangler 3.90.0 as a fallback, which can't deploy the v4-shaped build output produced by `@opennextjs/cloudflare`, causing `versions upload` to exit 1.

## Test plan
- [ ] PR's `Cloudflare Preview` check installs wrangler 4.87.0 on Node 22
- [ ] `versions upload` succeeds and the preview URL is commented on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)